### PR TITLE
patched file to support test in solutions and gtest build if present

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -64,10 +64,10 @@
         {
             "name": "test",
             "inherits": "debug",
-            "targets": [ "test" ],
-            "nativeToolOptions": [
-                "ARGS=--output-on-failure"
-            ]
+            "targets": [ "test" ]
+            // "nativeToolOptions": [
+            //  "ARGS=--output-on-failure"
+            // ]
         }
     ]
 }

--- a/build-one.sh
+++ b/build-one.sh
@@ -205,6 +205,19 @@ for EX in $EXERCISES; do
     cp -f "$SOLDIR/$EXDIR"/* src 2>/dev/null || true
   fi
 
+  # Check and copy test files if 'tests' directory exists
+  if [[ -d "$SOLDIR/$EXDIR/tests" ]]; then
+    trace "Copying test files from $SOLDIR/$EXDIR/tests"
+    rm -rf tests
+    mkdir tests
+    cp -f "$SOLDIR/$EXDIR/tests"/* tests 2>/dev/null || true
+  else
+    if [[ -d tests ]]; then
+      trace "Removing test files from tests"
+      rm -rf tests
+    fi
+  fi
+
   if [[ -z $COPY ]]; then
     # run build
     RTOS=


### PR DESCRIPTION
updated `build-one.sh` to look for a test folder in the solutions.
If present it copies the tests folder over and builds with `gtest`.
Removed the `nativeToolOptions` from `CMakePresets.json` as this was causing build failures on MacOS